### PR TITLE
Develop

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,11 +16,11 @@ project(khaiii VERSION ${KHAIII_VERSION})
 
 # options
 option(FMA "on/off fused multiply add compiler option" ON)
-if(FMA)
+if (FMA)
     include("cmake/FusedMultiplyAdd.cmake")
-endif()
+endif ()
 option(PROFILER "on/off profiler option" OFF)
-if(PROFILER)
+if (PROFILER)
     # bin/khaiii는 /tmp/bin_khaiii.prof 파일로, test/khaiii는 /tmp/test_khaiii.prof 파일로 생성됩니다.
     # 출력 파일명을 지정하고 싶을 경우 CPUPROFILE=/path/to/output bin/khanii와 같이 환경변수와 함께 실행합니다.
     # pprof --text bin/khaiii /tmp/bin_khaiii.prof와 같이 실행하면 출력 파일로부터 텍스트 보고서를 생성할 수 있습니다.
@@ -28,9 +28,9 @@ if(PROFILER)
     message(STATUS "[khaiii] profiler option enabled")
     include("cmake/FindGperftools.cmake")
     add_definitions(-DPROFILER)
-endif()
+endif ()
 option(COVERAGE "on/off code coverage option" OFF)
-if(COVERAGE AND CMAKE_COMPILER_IS_GNUCXX)
+if (COVERAGE AND CMAKE_COMPILER_IS_GNUCXX)
     # 코드 커버리지 옵션을 켭니다.
     # lcov --capture --directory . --output-file coverage.info
     # genhtml coverage.info --output-directory coverage.html
@@ -39,7 +39,8 @@ if(COVERAGE AND CMAKE_COMPILER_IS_GNUCXX)
     set(CMAKE_BUILD_TYPE Debug)
     include(cmake/CodeCoverage.cmake)
     APPEND_COVERAGE_COMPILER_FLAGS()
-endif()
+endif ()
+
 
 set(CMAKE_DEBUG_POSTFIX "_debug")
 
@@ -54,47 +55,47 @@ ae2f_CoreLibFetchX_NS(fmtlib fmt fmt master)
 ae2f_CoreLibFetchX_NS(gabime spdlog spdlog v1.x)
 
 find_package(nlohmann_json)
-if(NOT ${nlohmann_json_FOUND})
-	ae2f_CoreLibFetch_NS(nlohmann json json master)
-endif()
+if (NOT ${nlohmann_json_FOUND})
+    ae2f_CoreLibFetch_NS(nlohmann json json master)
+endif ()
 
 # dependent 3rd party libraries (Manual step needed)
 
 find_package(Eigen3)
-if(NOT ${Eigen3_FOUND})
-	ae2f_CoreLibFetch_NS(opm eigen3 eigen3 master)
-endif()
+if (NOT ${Eigen3_FOUND})
+    ae2f_CoreLibFetch_NS(opm eigen3 eigen3 master)
+endif ()
 
-find_package(Gtest)
-if(NOT ${Gtest_FOUND})
-	ae2f_CoreLibFetch_NS(google googletest googletest main)
-endif()
+find_package(GTest)
+if (NOT ${GTest_FOUND})
+    ae2f_CoreLibFetch_NS(google googletest googletest main)
+endif ()
 
 set(Boost_INCLUDE_DIR "")
 find_package(Boost)
-if(NOT ${Boost_FOUND})
-        
-        execute_process(COMMAND git clone https://github.com/boostorg/boost ${PROJECT_SOURCE_DIR}/.submod/boost --recursive)
-        file(GLOB subdirs LIST_DIRECTORIES true "${PROJECT_SOURCE_DIR}/.submod/boost/libs/*")
+if (NOT ${Boost_FOUND})
 
-        foreach(subdir ${subdirs})
-            if(IS_DIRECTORY ${subdir})
-                if(EXISTS ${subdir}/include AND IS_DIRECTORY ${subdir}/include)
-                        message(STATUS "Found directory: ${subdir}/include")
-                        list(APPEND Boost_INCLUDE_DIR ${subdir}/include)
-                endif()
-            endif()
-        endforeach()
-endif()
+    execute_process(COMMAND git clone https://github.com/boostorg/boost ${PROJECT_SOURCE_DIR}/.submod/boost --recursive)
+    file(GLOB subdirs LIST_DIRECTORIES true "${PROJECT_SOURCE_DIR}/.submod/boost/libs/*")
+
+    foreach (subdir ${subdirs})
+        if (IS_DIRECTORY ${subdir})
+            if (EXISTS ${subdir}/include AND IS_DIRECTORY ${subdir}/include)
+                message(STATUS "Found directory: ${subdir}/include")
+                list(APPEND Boost_INCLUDE_DIR ${subdir}/include)
+            endif ()
+        endif ()
+    endforeach ()
+endif ()
 
 include_directories(${Boost_INCLUDE_DIR})
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 add_definitions(-DFMT_HEADER_ONLY)
-if(NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
+if (NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
     add_definitions(-O3)
     add_definitions(-g)
     add_definitions(-funroll-loops)
-endif()
+endif ()
 
 # main objects
 add_library(obj_khaiii OBJECT
@@ -120,7 +121,7 @@ set(include_directories
         src/main/cpp
         ${Boost_INCLUDE_DIRS}
         ${EIGEN3_INCLUDE_DIR}
-        )
+)
 target_include_directories(obj_khaiii PUBLIC ${include_directories})
 target_compile_definitions(obj_khaiii PUBLIC -DPREFIX="${CMAKE_INSTALL_PREFIX}")
 
@@ -138,13 +139,13 @@ add_executable(bin_khaiii
 set_target_properties(bin_khaiii PROPERTIES
         OUTPUT_NAME khaiii
         RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin
-        )
+)
 target_include_directories(bin_khaiii PRIVATE ${include_directories})
 target_link_libraries(bin_khaiii PRIVATE
         cxxopts::cxxopts
         ${GPERFTOOLS_PROFILER}
         ${CMAKE_THREAD_LIBS_INIT}
-        )
+)
 
 # executable: test_khaiii
 add_executable(test_khaiii
@@ -157,7 +158,7 @@ add_executable(test_khaiii
 set_target_properties(test_khaiii PROPERTIES
         OUTPUT_NAME khaiii
         RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/test
-        )
+)
 target_include_directories(test_khaiii PRIVATE
         src/test/cpp
         ${include_directories})
@@ -166,9 +167,15 @@ target_link_libraries(test_khaiii PRIVATE
         cxxopts::cxxopts
         ${GPERFTOOLS_PROFILER}
         ${CMAKE_THREAD_LIBS_INIT})
-if(COVERAGE AND CMAKE_COMPILER_IS_GNUCXX)
+if (COVERAGE AND CMAKE_COMPILER_IS_GNUCXX)
     target_link_libraries(test_khaiii PRIVATE gcov)
-endif()
+endif ()
+
+if (WIN32)
+    target_link_libraries(khaiii PRIVATE shlwapi)
+    target_link_libraries(bin_khaiii PRIVATE shlwapi)
+    target_link_libraries(test_khaiii PRIVATE shlwapi)
+endif ()
 
 # resource
 add_custom_target(resource

--- a/src/main/cpp/khaiii/util.hpp
+++ b/src/main/cpp/khaiii/util.hpp
@@ -3,15 +3,17 @@
  * @copyright  Copyright (C) 2017-, Kakao Corp. All rights reserved.
  */
 
-
 #ifndef SRC_MAIN_CPP_KHAIII_UTIL_HPP_
 #define SRC_MAIN_CPP_KHAIII_UTIL_HPP_
-
 
 //////////////
 // includes //
 //////////////
+#ifdef _WIN32
+#include <shlwapi.h>
+#else
 #include <sys/stat.h>
+#endif    // _WIN32
 
 #include <sstream>
 #include <string>
@@ -20,79 +22,109 @@
 #include <vector>
 #include <cassert>
 #include <memory>
+#include <iomanip>
+#include <map>
 
 #include "boost/locale/encoding_utf.hpp"
 
+#pragma once
 
 namespace khaiii {
-
-
-
-///////////////
-// functions //
-///////////////
-/**
- * whether is space or not
- * @param  chr  character
- * @return  true if character is space
- */
-inline bool is_space(wchar_t chr) {
-    static std::wstring space(L" \t\v\r\n\u3000");
-    return space.find(chr) != std::wstring::npos;
-}
-
-
-/**
- * convert UTF-8 string to wstring
- * @param str  UTF-8 string
- * @return  wstring
- */
-inline std::wstring utf8_to_wstr(const char* str) {
-	assert(str);
-    return boost::locale::conv::utf_to_utf<wchar_t>(str, str + ::strlen(str));
-}
-
-
-/**
- * convert wstring to UTF-8 string
- * @param  wstr  wstring
- * @return  UTF-8 string
- */
-inline std::string wstr_to_utf8(const wchar_t* wstr) {
-	assert(wstr);
-    return boost::locale::conv::utf_to_utf<char>(wstr, wstr + ::wcslen(wstr));
-}
-
-
-/**
- * string splitter
- * @param  str  string to split
- * @param  deilm  delimiter char
- * @return  list of splitted strings
- */
-inline std::vector<std::string> split(const char* str, char delim) {
-    std::stringstream sss(str);
-    std::vector<std::string> elems;
-    for (std::string item; std::getline(sss, item, delim); ) {
-        elems.emplace_back(std::move(item));
+    ///////////////
+    // functions //
+    ///////////////
+    /**
+     * whether is space or not
+     * @param  chr  character
+     * @return  true if character is space
+     */
+    inline bool is_space(wchar_t chr) {
+        static std::wstring space(L" \t\v\r\n\u3000");
+        return space.find(chr) != std::wstring::npos;
     }
-    return elems;
-}
 
+    /**
+     * convert UTF-8 string to wstring
+     * @param str  UTF-8 string
+     * @return  wstring
+     */
+    inline std::wstring utf8_to_wstr(const char* str) {
+        assert(str);
+        return boost::locale::conv::utf_to_utf<wchar_t>(str, str + ::strlen(str));
+    }
 
-/**
- * whether file (or directory) exists or not
- * @param  path  path
- * @return  true if exists
- */
-inline bool file_exists(const char* path) {
-	assert(path);
-    struct stat st;
-    return stat(path, &st) == 0;
-}
+    /**
+     * convert wstring to UTF-8 string
+     * @param  wstr  wstring
+     * @return  UTF-8 string
+     */
+    inline std::string wstr_to_utf8(const wchar_t* wstr) {
+        assert(wstr);
+        return boost::locale::conv::utf_to_utf<char>(wstr, wstr + ::wcslen(wstr));
+    }
 
+    /**
+     * string splitter
+     * @param  str  string to split
+     * @param  deilm  delimiter char
+     * @return  list of splitted strings
+     */
+    inline std::vector<std::string> split(const char* str, char delim) {
+        std::stringstream sss(str);
+        std::vector<std::string> elems;
+        for (std::string item; std::getline(sss, item, delim);) {
+            elems.emplace_back(std::move(item));
+        }
+        return elems;
+    }
 
-}    // namespace khaiii
+    inline std::string const_char_to_bytestring(const char* str) {
+        if (str == nullptr) {
+            return "nullptr";
+        }
+        std::stringstream hex_stream;
+        std::map<int, std::string> hex_map = {
+            { 0x07, R"(\a)" },
+            { 0x08, R"(\b)" },
+            { 0x1b, R"(\e)" },
+            { 0x0c, R"(\f)" },
+            { 0x0a, R"(\n)" },
+            { 0x0d, R"(\r)" },
+            { 0x09, R"(\t)" },
+            { 0x0b, R"(\v)" },
+        };
 
+        for (int i = 0; str[i] != '\0'; i++) {
+            unsigned char byte = static_cast<unsigned char>(str[i]);
+            if (static_cast<int>(' ') <= byte && byte <= static_cast<int>('~')) {
+                hex_stream << str[i];
+            }
+            else if (hex_map.find(byte) != hex_map.end()) {
+                hex_stream << hex_map.at(byte);
+            }
+            else {
+                hex_stream << "\\x" << std::hex << std::setw(2) << std::setfill('0')
+                    << static_cast<int>(byte);
+            }
+        }
+
+        return hex_stream.str();
+    }
+
+    /**
+     * whether file (or directory) exists or not
+     * @param  path  path
+     * @return  true if exists
+     */
+    inline bool file_exists(const char* path) {
+        assert(path);
+#ifdef _WIN32
+        return PathFileExistsA(path);
+#else
+        struct stat st;
+        return stat(path, &st) == 0;
+#endif    // _WIN32
+    }
+} // namespace khaiii
 
 #endif    // SRC_MAIN_CPP_KHAIII_UTIL_HPP_

--- a/src/test/cpp/khaiii/KhaiiiApiTest.cpp
+++ b/src/test/cpp/khaiii/KhaiiiApiTest.cpp
@@ -15,7 +15,10 @@
 #include "cxxopts.hpp"
 
 #include "khaiii/KhaiiiApi.hpp"
-
+#include "khaiii/util.hpp"
+#ifdef _WIN32
+#include "windows.h"
+#endif
 
 ///////////////
 // variables //
@@ -31,6 +34,14 @@ using std::ostringstream;
 // methods //
 /////////////
 void KhaiiiApiTest::SetUp() {
+    // Call the parent SetUp first
+    ::testing::Test::SetUp();
+
+#ifdef _WIN32
+    SetConsoleOutputCP(CP_UTF8);
+    SetConsoleCP(CP_UTF8);
+#endif
+
     string rsc_dir = (*prog_args)["rsc-dir"].as<string>();
     _handle = khaiii_open(rsc_dir.c_str(), "");
     ASSERT_GT(_handle, 0);

--- a/src/test/cpp/khaiii/KhaiiiDevTest.cpp
+++ b/src/test/cpp/khaiii/KhaiiiDevTest.cpp
@@ -14,7 +14,7 @@
 
 #include "khaiii/ErrPatch.hpp"
 #include "khaiii/KhaiiiApiTest.hpp"
-
+#include "khaiii/util.hpp"
 
 using std::array;
 using std::string;
@@ -32,9 +32,9 @@ class KhaiiiDevTest: public KhaiiiApiTest {};
 TEST_F(KhaiiiDevTest, analyze_bfr_errorpatch) {
     array<int16_t, 13> output;
     EXPECT_EQ(13, khaiii_analyze_bfr_errpatch(_handle, u8"진정한 테스트입니다.", "", &output[0]));
-    EXPECT_EQ(khaiii::ErrPatch::SENT_DELIM_NUM, output[0]);    // bos/eos
-    EXPECT_EQ(khaiii::ErrPatch::WORD_DELIM_NUM, output[4]);    // bow/eow
-    EXPECT_EQ(khaiii::ErrPatch::SENT_DELIM_NUM, output[12]);    // bos/eos
+    EXPECT_EQ(khaiii::ErrPatch::SENT_DELIM_NUM, static_cast<wchar_t>(output[0]));    // bos/eos
+    EXPECT_EQ(khaiii::ErrPatch::WORD_DELIM_NUM, static_cast<wchar_t>(output[4]));    // bow/eow
+    EXPECT_EQ(khaiii::ErrPatch::SENT_DELIM_NUM, static_cast<wchar_t>(output[12]));   // bos/eos
 
     EXPECT_GT(0, khaiii_analyze_bfr_errpatch(-1, u8"", "", &output[0]));    // invalid handle
     EXPECT_GT(0, khaiii_analyze_bfr_errpatch(_handle, nullptr, "", &output[0]));    // null input


### PR DESCRIPTION
설명 (Description)
----
1. 인코딩 이슈가 터지던 걸 api test에서 windows 환경에서만 utf8을 시작할 때 강제하게 해서 해결함. 다만 형태소 분석이 현재 정상적으로 진행되지 않는 이슈가 있음
2. file_exists의 windows 대응 버전 제작 shlwapi의 PathFileExistsA 함수를 이용. 이를 위해 CMakeList.txt를 변경해야했음. (line 172~178)
3. dev test에서 리미터의 데이터 타입은 wchar_t인데, output은 int16_t[]기 때문에 MinGW-GCC 14.1 환경에서 그 둘이 값이 달라지는 현상이 있었음. 따라서 output의 값을 wchar_t로 casting해서 비교하게 함.
4. 바이트 형식을 보기 위해 const_char_to_bytestring 함수를 추가함. 이 함수는 escape sequence가 있는 바이트는 hex_map에서 찾아 별도의 string representation을 가지고, `" "`(space, ascii 0x20)부터 `"~"`(ascii 0x7E)까지는 그냥 프린팅하고, 나머지 바이트는 `\x00`(00은 16진수 두 자리임) 형식으로 프린팅해주는 함수임. 디버깅 용도로 제작함.
escape sequence가 있는 바이트는 다음과 같음.
```
0x07: \a
0x08: \b
0x1b: \e
0x0c: \f
0x0a: \n
0x0d: \r
0x09: \t
0x0b: \v
```
5. CMakeList.txt를 수정하며 리팩토링을 진행함. 리팩토링은 CLion의 reformat code 기능을 이용하여 진행함.

개발자를 위한 가이드 (Developer's Guide)
----
만약 khaiii에 pull request가 처음이라면 [개발자를 위한 가이드](https://github.com/kakao/khaiii/wiki#%EA%B0%9C%EB%B0%9C%EC%9E%90%EB%A5%BC-%EC%9C%84%ED%95%9C-%EA%B0%80%EC%9D%B4%EB%93%9C) 문서들을 한번 읽어보시길 권고드립니다.

If this is your first pull request for khaiii, please see the [Developer's Guide](https://github.com/kakao/khaiii/wiki#%EA%B0%9C%EB%B0%9C%EC%9E%90%EB%A5%BC-%EC%9C%84%ED%95%9C-%EA%B0%80%EC%9D%B4%EB%93%9C).


체크 리스트 (Checklist)
----
pull request 전에 아래 체크 리스트들을 만족하는 지 확인한 후 체크('x') 표시를 해주시기 바랍니다.

Before you submit pull requests, please check(set 'x') to the checklist below.

- [ ] master 브랜치가 아니라 **develop** 브랜치에 머지하도록 pull request를 작성 중이신가요? (Did you merge into **develop** branch not master?)
- [ ] `build/test/khaiii` 프로그램을 실행하여 **테스트**가 성공했나요? (Did all **tests** are passed when you ran as `build/test/khaiii`)
- [ ] **PyLint** 툴을 실행하여 발생한 에러를 모두 수정하셨나요? (Did you fix all errors after running **PyLint**?)
- [ ] **CppLint** 툴을 실행하여 발생한 에러를 모두 수정하셨나요? (Did you fix all errors after running **CppLint**?)
